### PR TITLE
chore(ci): Add CI file for dependabot

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -1,0 +1,33 @@
+name: Initialization action
+description: Common actions to initialize a Job
+
+inputs:
+  jdk:
+    description: Version of JDK that must be loaded.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK
+      if: ${{ inputs.jdk != '' }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ inputs.jdk }}
+        distribution: adopt
+
+    - name: Cache gradle
+      if: ${{ inputs.jdk != '' }}
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Set permission to execute gradle
+      if: ${{ inputs.jdk != '' }}
+      shell: bash
+      run: chmod +x gradlew

--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -1,0 +1,47 @@
+name: Check
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot-**'
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+    branches:
+      - master
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v3
+
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        distribution: adopt
+
+    - name: Set permission to execute gradle
+      run: chmod +x gradlew
+
+    - name: Build
+      uses: gradle/gradle-build-action@v2.1.6
+      with:
+        arguments: build -x test
+
+    - name: Test
+      uses: gradle/gradle-build-action@v2.1.6
+      with:
+        arguments: test
+
+    - name: Test Summary
+      if: always()
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      with:
+        files: "**/build/test-results/test/TEST-*.xml"

--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -21,24 +21,10 @@ jobs:
     - name: Checkout project
       uses: actions/checkout@v3
 
-    - name: Set up JDK
-      uses: actions/setup-java@v3
+    - name: Initialization
+      uses: ./.github/actions/init
       with:
-        java-version: 17
-        distribution: adopt
-
-    - name: Cache gradle
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-
-    - name: Set permission to execute gradle
-      run: chmod +x gradlew
+        jdk: 17
 
     - name: Build
       uses: gradle/gradle-build-action@v2.1.6

--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -27,6 +27,16 @@ jobs:
         java-version: 17
         distribution: adopt
 
+    - name: Cache gradle
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
     - name: Set permission to execute gradle
       run: chmod +x gradlew
 

--- a/.github/workflows/CheckDependabot.yml
+++ b/.github/workflows/CheckDependabot.yml
@@ -12,24 +12,10 @@ jobs:
     - name: Checkout project
       uses: actions/checkout@v3
 
-    - name: Set up JDK
-      uses: actions/setup-java@v3
+    - name: Initialization
+      uses: ./.github/actions/init
       with:
-        java-version: 17
-        distribution: adopt
-
-    - name: Cache gradle
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-
-    - name: Set permission to execute gradle
-      run: chmod +x gradlew
+        jdk: 17
 
     - name: Build
       uses: gradle/gradle-build-action@v2.1.6

--- a/.github/workflows/CheckDependabot.yml
+++ b/.github/workflows/CheckDependabot.yml
@@ -1,16 +1,9 @@
-name: Build
+name: Check-Dependabot
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
-  workflow_dispatch:
+  pull_request_target:
     branches:
-      - master
-
-concurrency:
-  group: check-${{ github.ref }}
-  cancel-in-progress: true
+      - 'dependabot-**'
 
 jobs:
   build:
@@ -37,9 +30,3 @@ jobs:
       uses: gradle/gradle-build-action@v2.1.6
       with:
         arguments: test
-
-    - name: Test Summary
-      if: always()
-      uses: EnricoMi/publish-unit-test-result-action@v1
-      with:
-        files: "**/build/test-results/test/TEST-*.xml"

--- a/.github/workflows/CheckDependabot.yml
+++ b/.github/workflows/CheckDependabot.yml
@@ -18,6 +18,16 @@ jobs:
         java-version: 17
         distribution: adopt
 
+    - name: Cache gradle
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
     - name: Set permission to execute gradle
       run: chmod +x gradlew
 


### PR DESCRIPTION
# Context

The current CI is triggered no matter the type of commit, by a user or dependabot.

# TODO

- [x] Create CI for dependabot
- [x] Ignore dependabot commit for user CI