### PR TITLE
fix(ci): Remove test report for dependabot branches

### DIFF
--- a/.github/workflows/CheckDependabot.yml
+++ b/.github/workflows/CheckDependabot.yml
@@ -21,8 +21,3 @@ jobs:
       uses: gradle/gradle-build-action@v2.1.6
       with:
         arguments: build -x test
-
-    - name: Test
-      uses: gradle/gradle-build-action@v2.1.6
-      with:
-        arguments: test


### PR DESCRIPTION
# Context

When a dependabot's PR is created, the CI failed because the test report has not the permission to publish result.

I consider the result has not useful for dependanbot, so we can remove it