### PR TITLE
fix(gradle): Jitpack publish properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,7 +140,7 @@ val javadocJar by tasks.registering(Jar::class) {
 
 publishing {
     publications {
-        create<MavenPublication>(Library.name) {
+        create<MavenPublication>("maven") {
             from(components["kotlin"])
             groupId = Library.group
             artifactId = Library.name

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,9 +6,6 @@ plugins {
     signing
 }
 
-group = Library.group
-version = Library.version
-
 buildscript {
     repositories {
         mavenCentral()
@@ -142,14 +139,14 @@ publishing {
     publications {
         create<MavenPublication>("maven") {
             from(components["kotlin"])
-            groupId = Library.group
-            artifactId = Library.name
-            version = Library.version
+            groupId = project.properties["group"] as? String? ?: "org.universe"
+            artifactId = project.name
+            version = project.properties["version"] as? String? ?: "1.0"
 
             artifact(sourcesJar.get())
 
             pom {
-                name.set(Library.name)
+                name.set(project.name)
                 description.set(Library.description)
                 url.set(Library.url)
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -25,10 +25,6 @@ object License {
 }
 
 object Library {
-    const val name = "dataservice"
-    const val group = "org.universe"
     const val description = "Allows data management through a cache and a database"
     const val url = "${Organization.url}/DataService"
-    val version: String
-        get() = System.getenv("RELEASE_TAG") ?: undefined
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
during the jitpack publish, some issue appears : 

- Jitpack uses a JDK 8
- Gradle doesn't use the properties sent by Jitpack